### PR TITLE
ノート検索機能（キーワードおよびカテゴリー）の追加

### DIFF
--- a/resources/views/notes/index.blade.php
+++ b/resources/views/notes/index.blade.php
@@ -22,6 +22,12 @@
         <button type="submit" style="margin-left: 8px;">検索</button>
     </form>
 
+    @if(request()->filled('keyword') || request()->filled('category_id'))
+        <p style="color:gray;">
+            検索結果：{{ $notes->count() }}件
+        </p>
+    @endif
+
     <ul>
         @forelse($notes as $note)
             <div style="border: 1px solid #ccc; padding: 1rem; margin-bottom: 1rem;">
@@ -42,7 +48,7 @@
                 </form>
             </div>
         @empty
-            <li>ノートがありません。</li>
+            <li>該当する投稿がありません。</li>
         @endforelse
     </ul>
 @endsection

--- a/resources/views/notes/index.blade.php
+++ b/resources/views/notes/index.blade.php
@@ -9,6 +9,19 @@
 
     <a href="{{ route('notes.create') }}">ノートを新規作成</a>
 
+    <form action="{{ route('notes.index') }}" method="GET" style="margin-bottom: 16px;">
+        <input type="text" name="keyword" value="{{ request('keyword') }}" placeholder="キーワードで検索" style="width: 200px;">
+        <select name="category_id" style="margin-left: 8px;">
+            <option value="">すべてのカテゴリ</option>
+            @foreach ($categories as $category)
+                <option value="{{ $category->id }}" {{ request('category_id') == $category->id ? 'selected' : '' }}>
+                    {{ $category->name }}
+                </option>
+            @endforeach
+        </select>
+        <button type="submit" style="margin-left: 8px;">検索</button>
+    </form>
+
     <ul>
         @forelse($notes as $note)
             <div style="border: 1px solid #ccc; padding: 1rem; margin-bottom: 1rem;">


### PR DESCRIPTION
## 概要
キーワードおよびカテゴリを用いたノートの検索機能を追加しました。

## 実装内容
- 投稿一覧ページに検索フォームを追加
- 投稿一覧ページに検索ヒット数を追加
- キーワード検索は、タイトルまたは記事の内容をOR検索する
- 空白区切りで複数のキーワードを用いた検索に対応
- カテゴリ検索は、プルダウンリストから選択

## 備考
なし