### PR TITLE
ゲストユーザーも記事一覧・記事詳細を閲覧可能に（認可制御の調整）

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -37,6 +37,6 @@ class LoginController extends Controller
         $request->session()->invalidate();
         $request->session()->regenerateToken();
 
-        return redirect('/login');
+        return redirect()->route('notes.index');
     }
 }

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -2,5 +2,5 @@
 
 @section('content')
     <p>ログイン成功</p>
-    <a href="/notes">My Notes</a> 
+    <a href="{{ route('notes.index') }}">My Notes</a> 
 @endsection

--- a/resources/views/notes/index.blade.php
+++ b/resources/views/notes/index.blade.php
@@ -7,7 +7,9 @@
         <div style="color: green;">{{ session('success') }}</div>
     @endif
 
-    <a href="{{ route('notes.create') }}">ノートを新規作成</a>
+    @auth
+        <a href="{{ route('notes.create') }}">ノートを新規作成</a>
+    @endauth
 
     <form action="{{ route('notes.index') }}" method="GET" style="margin-bottom: 16px;">
         <input type="text" name="keyword" value="{{ request('keyword') }}" placeholder="キーワードで検索" style="width: 200px;">
@@ -39,13 +41,15 @@
                 <p style="color: gray;">カテゴリ: {{ $note->category->name }}</p>
                 <p>いいね数: {{ $note->likes_count }}</p>
 
-                <a href="{{ route('notes.edit', $note) }}">編集</a>
+                @auth
+                    <a href="{{ route('notes.edit', $note) }}">編集</a>
 
-                <form action="{{ route('notes.destroy', $note) }}" method="POST" style="display:inline;">
-                    @csrf
-                    @method('DELETE')
-                    <button type="submit" onclick="return confirm('本当に削除しますか？')">削除</button>
-                </form>
+                    <form action="{{ route('notes.destroy', $note) }}" method="POST" style="display:inline;">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" onclick="return confirm('本当に削除しますか？')">削除</button>
+                    </form>
+                @endauth
             </div>
         @empty
             <li>該当する投稿がありません。</li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\CommentController;
 use App\Http\Controllers\LikeController;
 
-Route::get('/notes', [NoteController::class, 'index'])
+Route::get('/', [NoteController::class, 'index'])
     ->name('notes.index');
 
 Route::middleware(['auth'])->group(function() {

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,9 @@ use App\Http\Controllers\LikeController;
 Route::get('/', [NoteController::class, 'index'])
     ->name('notes.index');
 
+Route::get('/notes/{note}', [NoteController::class, 'show'])
+    ->name('notes.show');
+
 Route::middleware(['auth'])->group(function() {
     Route::get('/home', function() { return view('home'); })
         ->name('home');
@@ -32,9 +35,6 @@ Route::middleware(['auth'])->group(function() {
 
     Route::post('/notes', [NoteController::class, 'store'])
         ->name('notes.store');
-
-    Route::get('/notes/{note}', [NoteController::class, 'show'])
-        ->name('notes.show');
 
     Route::get('/notes/{note}/edit', [NoteController::class, 'edit'])
         ->name('notes.edit');

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,9 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\CommentController;
 use App\Http\Controllers\LikeController;
 
+Route::get('/notes', [NoteController::class, 'index'])
+    ->name('notes.index');
+
 Route::middleware(['auth'])->group(function() {
     Route::get('/home', function() { return view('home'); })
         ->name('home');
@@ -23,9 +26,6 @@ Route::middleware(['auth'])->group(function() {
 
     Route::put('/profile/edit', [ProfileController::class, 'update'])
         ->name('profile.update');
-    
-    Route::get('/notes', [NoteController::class, 'index'])
-        ->name('notes.index');
 
     Route::get('/notes/create', [NoteController::class, 'create'])
         ->name('notes.create');


### PR DESCRIPTION
## 概要
Issue #8

## 変更点
- 記事一覧画面（notes/index.blade.php）
    - ゲストユーザーでアクセス可能に
    - ゲストユーザーに対して、ノートの作成、編集、削除ボタンを隠蔽
    - パスを`/note`から`/`に
- 記事詳細画面（notes/show.blade.php）
    - ゲストユーザーでアクセス可能に

## 補足
- 該当画面への遷移元のリンク指定を変更（`/note` -> `route(notes.index)`など）
- 記事詳細画面のゲストユーザーに対する、いいね機能やコメント機能の隠蔽は実装済み

Closes #8