### PR TITLE
ホーム画面を記事一覧画面へ差し替え（Closes #10）

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -22,7 +22,7 @@ class LoginController extends Controller
 
         if (Auth::attempt($credentials)) {
             $request->session()->regenerate();
-            return redirect()->intended('/home');
+            return redirect()->route('notes.index');
         }
 
         return back()->withErrors([

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -30,6 +30,6 @@ class RegisterController extends Controller
 
         auth()->login($user);
 
-        return redirect()->route('home');
+        return redirect()->route('notes.index');
     }
 }

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,6 +1,0 @@
-@extends('layouts.app')
-
-@section('content')
-    <p>ログイン成功</p>
-    <a href="{{ route('notes.index') }}">My Notes</a> 
-@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,9 +15,6 @@ Route::get('/notes/{note}', [NoteController::class, 'show'])
     ->name('notes.show');
 
 Route::middleware(['auth'])->group(function() {
-    Route::get('/home', function() { return view('home'); })
-        ->name('home');
-
     Route::post('/logout', [LoginController::class, 'destroy'])
         ->name('logout');
 


### PR DESCRIPTION
## 概要
ホーム画面を仮置きの`home.blade.php`から`notes/index.blade.php`へ差し替えました。

## 変更点
- LoginController
  - ログイン後のリダイレクト先を記事一覧画面へ変更
- RegisterController
  - 登録後のリダイレクト先を記事一覧画面へ変更
- web.php
  - home.blade.phpへのルートを削除
- home.blade.php
  - ファイルを削除