### PR TITLE
記事作成画面が404を返すバグの修正

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ Route::get('/', [NoteController::class, 'index'])
     ->name('notes.index');
 
 Route::get('/notes/{note}', [NoteController::class, 'show'])
+    ->where('note', '[0-9]+')
     ->name('notes.show');
 
 Route::middleware(['auth'])->group(function() {


### PR DESCRIPTION
## 概要
Issue #18 

## 原因
ルート定義のミス。
`/notes/create`へのリクエストを`notes.show`が拾っていた。

## 対応
`notes.show`のルート定義に条件を追加して`/notes/create`へのリクエストをスルーするようにした。

## 補足
ルート定義の順番（ミドルウェアなし -> auth -> guest）を保つため、順番はそのままに前述の条件追加で対応。

Closes 18